### PR TITLE
Update feeder and spark notebooks to use new producer API

### DIFF
--- a/feeder/src/main/scala/com/bythebay/pipeline/akka/feeder/FeederActor.scala
+++ b/feeder/src/main/scala/com/bythebay/pipeline/akka/feeder/FeederActor.scala
@@ -1,7 +1,7 @@
 package com.bythebay.pipeline.akka.feeder 
 
 import akka.actor.{Props, Actor, ActorLogging}
-import kafka.producer.KeyedMessage
+import org.apache.kafka.clients.producer.{ProducerRecord,Callback,RecordMetadata}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
@@ -26,8 +26,13 @@ class FeederActor extends Actor with ActorLogging with FeederExtensionActor {
     case SendNextLine if dataIter.hasNext =>
       val nxtRating = dataIter.next()
       log.info(s"Sending next rating: $nxtRating")
-      feederExtension.producer.send(new KeyedMessage[String, String](feederExtension.kafkaTopic, nxtRating.split(",")(0), nxtRating))
-
+      val record = new ProducerRecord[String,String](feederExtension.kafkaTopic, nxtRating.split(",")(0), nxtRating)
+      val future = feederExtension.producer.send(record, new Callback {
+        override def onCompletion(result: RecordMetadata, exception: Exception) {
+          if (exception != null) println("Failed to send record: " + exception)
+        }
+      })
+      // Use future.get() to make this a synchronous write
   }
 
   def initData() = {

--- a/feeder/src/main/scala/com/bythebay/pipeline/akka/feeder/FeederExtension.scala
+++ b/feeder/src/main/scala/com/bythebay/pipeline/akka/feeder/FeederExtension.scala
@@ -3,7 +3,7 @@ package com.bythebay.pipeline.akka.feeder
 import java.util.Properties
 
 import akka.actor._
-import kafka.producer.{Producer, ProducerConfig}
+import org.apache.kafka.clients.producer.{KafkaProducer,ProducerConfig}
 
 object FeederExtension extends ExtensionKey[FeederExtension]
 
@@ -16,11 +16,11 @@ class FeederExtension(system: ExtendedActorSystem) extends Extension {
   val kafkaTopic = systemConfig.getString("pipeline.kafkaTopic")
 
   val props = new Properties()
-  props.put("metadata.broker.list", kafkaHost)
-  props.put("serializer.class", "kafka.serializer.StringEncoder")
+  props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
+  props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+  props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
 
-  val producerConfig = new ProducerConfig(props)
-  val producer = new Producer[String, String](producerConfig)
+  val producer = new KafkaProducer[String, String](props)
 
 }
 

--- a/notebooks/spark-notebook/pipeline/Ratings from Cassandra.snb
+++ b/notebooks/spark-notebook/pipeline/Ratings from Cassandra.snb
@@ -70,10 +70,10 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "import java.util.Properties\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nimport kafka.producer.{KeyedMessage, Producer, ProducerConfig}\n\nval props = new Properties()\nprops.put(\"metadata.broker.list\", \"localhost:9092,localhost:9093\")\nprops.put(\"serializer.class\", \"kafka.serializer.StringEncoder\")\nval producerConfig = new ProducerConfig(props)\nval producer = new Producer[String, String](producerConfig)\n\n// Guard to stop the producer\nvar stopSending = false\n\n// future that issues a future.\n// a future sends a message after having waited for up to 500ms\ndef sendMsg:Unit = Future {\n  Thread.sleep((scala.util.Random.nextDouble * 500).toLong)\n  producer.send {\n    val msg = Rating(scala.util.Random.nextInt(10000), scala.util.Random.nextInt(10), scala.util.Random.nextInt(10000))\n    new KeyedMessage[String, String](\"ratings\", msg.fromUserId.toString, msg.toCSV)\n  }\n  if (!stopSending) sendMsg\n}\nsendMsg",
+    "source" : "import java.util.Properties\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nimport org.apache.kafka.clients.producer.{KafkaProducer,ProducerConfig,ProducerRecord}\n\nval props = new Properties()\nprops.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, \"localhost:9092,localhost:9093\")\nprops.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, \"org.apache.kafka.common.serialization.StringSerializer\")\nprops.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, \"org.apache.kafka.common.serialization.StringSerializer\")\nval producer = new KafkaProducer[String, String](props)\n\n// Guard to stop the producer\nvar stopSending = false\n\n// future that issues a future.\n// a future sends a message after having waited for up to 500ms\ndef sendMsg:Unit = Future {\n  Thread.sleep((scala.util.Random.nextDouble * 500).toLong)\n  producer.send {\n    val msg = Rating(scala.util.Random.nextInt(10000), scala.util.Random.nextInt(10), scala.util.Random.nextInt(10000))\n    new ProducerRecord[String, String](\"ratings\", msg.fromUserId.toString, msg.toCSV)\n  }\n  if (!stopSending) sendMsg\n}\nsendMsg",
     "outputs" : [ ]
   }, {
     "metadata" : { },
@@ -87,7 +87,7 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
     "source" : "import org.apache.spark.streaming.Seconds\nimport org.apache.spark.streaming.StreamingContext\n\nval ssc = new StreamingContext(sc, Seconds(2))\nval brokers = \"localhost:9092,localhost:9093\"\nval topics = Set(\"ratings\")\nval kafkaParams = Map[String, String](\"metadata.broker.list\" -> brokers)",
@@ -100,7 +100,7 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
     "source" : "import org.apache.spark.streaming.kafka.KafkaUtils\nimport org.apache.spark.streaming.Time\nimport kafka.serializer.StringDecoder\n\n// connect (direct) to kafka\nval ratingsStream = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](\n  ssc, kafkaParams, topics)\n\n// transform the CSV Strings into Ratings\nval msgs = ratingsStream.foreachRDD { (message: RDD[(String, String)], batchTime: Time) => \n  // convert each RDD from the batch into a DataFrame\n  val df = message.map(_._2.split(\",\"))\n                  .map(rating => \n                       Rating(rating(0).trim.toInt, rating(1).trim.toInt, rating(2).trim.toInt)\n                  ).toDF(\"fromuserid\", \"touserid\", \"rating\")\n\n  // add the batch time to the DataFrame\n  val dfWithBatchTime = df.withColumn(\"batchtime\", org.apache.spark.sql.functions.lit(batchTime.milliseconds))\n\n  // save the DataFrame to Cassandra\n  // Note:  Cassandra has been initialized through spark-env.sh\n  //        Specifically, export SPARK_JAVA_OPTS=-Dspark.cassandra.connection.host=127.0.0.1\n  dfWithBatchTime.write.format(\"org.apache.spark.sql.cassandra\")\n    .mode(SaveMode.Append)\n    .options(Map(\"keyspace\" -> \"pipeline\", \"table\" -> \"real_time_ratings\"))\n    .save()\n}",
@@ -113,7 +113,7 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
     "source" : "ssc.start()",
@@ -194,6 +194,15 @@
     },
     "cell_type" : "code",
     "source" : "//stopSending=true",
+    "outputs" : [ ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "input_collapsed" : false,
+      "collapsed" : true
+    },
+    "cell_type" : "code",
+    "source" : "",
     "outputs" : [ ]
   } ],
   "nbformat" : 4

--- a/notebooks/spark-notebook/pipeline/Ratings from Kafka.snb
+++ b/notebooks/spark-notebook/pipeline/Ratings from Kafka.snb
@@ -65,10 +65,10 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "import java.util.Properties\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nimport kafka.producer.{KeyedMessage, Producer, ProducerConfig}\n\nval props = new Properties()\nprops.put(\"metadata.broker.list\", \"localhost:9092,localhost:9093\")\nprops.put(\"serializer.class\", \"kafka.serializer.StringEncoder\")\nval producerConfig = new ProducerConfig(props)\nval producer = new Producer[String, String](producerConfig)\n\n// Guard to stop the producer\nvar stopSending = false\n\n// future that issues a future.\n// a future sends a message after having waited for up to 500ms\ndef sendMsg:Unit = Future {\n  Thread.sleep((scala.util.Random.nextDouble * 500).toLong)\n  producer.send {\n    val msg = Rating(scala.util.Random.nextInt(10000), scala.util.Random.nextInt(10), scala.util.Random.nextInt(10000))\n    new KeyedMessage[String, String](\"ratings\", msg.fromUserId.toString, msg.toCSV)\n  }\n  if (!stopSending) sendMsg\n}\nsendMsg",
+    "source" : "import java.util.Properties\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nimport org.apache.kafka.clients.producer.{KafkaProducer,ProducerConfig,ProducerRecord}\n\nval props = new Properties()\nprops.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, \"localhost:9092,localhost:9093\")\nprops.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, \"org.apache.kafka.common.serialization.StringSerializer\")\nprops.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, \"org.apache.kafka.common.serialization.StringSerializer\")\nval producer = new KafkaProducer[String, String](props)\n\n// Guard to stop the producer\nvar stopSending = false\n\n// future that issues a future.\n// a future sends a message after having waited for up to 500ms\ndef sendMsg:Unit = Future {\n  Thread.sleep((scala.util.Random.nextDouble * 500).toLong)\n  producer.send {\n    val msg = Rating(scala.util.Random.nextInt(10000), scala.util.Random.nextInt(10), scala.util.Random.nextInt(10000))\n    new ProducerRecord[String, String](\"ratings\", msg.fromUserId.toString, msg.toCSV)\n  }\n  if (!stopSending) sendMsg\n}\nsendMsg",
     "outputs" : [ ]
   }, {
     "metadata" : { },
@@ -155,7 +155,7 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
     "source" : "//ssc.stop(false) // commented in case of a Run All ^^",
@@ -168,10 +168,19 @@
     "metadata" : {
       "trusted" : true,
       "input_collapsed" : false,
-      "collapsed" : true
+      "collapsed" : false
     },
     "cell_type" : "code",
     "source" : "//stopSending = true // commented in case of a Run All ^^",
+    "outputs" : [ ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "input_collapsed" : false,
+      "collapsed" : true
+    },
+    "cell_type" : "code",
+    "source" : "",
     "outputs" : [ ]
   } ],
   "nbformat" : 4


### PR DESCRIPTION
The new implementation is much nicer and the preferred API now that it has stabilized.
